### PR TITLE
Fix path for testing out rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ To help with determining a good threshold, each error which will tell you how mu
 You can try the example configuration above out by running the following command:
 
 ```bash
-elm-review --template MartinSStewart/elm-review-remove-duplicate-code/example
+elm-review --template MartinSStewart/elm-review-remove-duplicate-code/preview
 ```


### PR DESCRIPTION
The example in the README looks for /example, but it's called /preview